### PR TITLE
welcome message: add new lines to prevent horizontal scroll

### DIFF
--- a/bin/welcome_message.sh
+++ b/bin/welcome_message.sh
@@ -7,8 +7,12 @@ $SEPARATOR
 
 You have successfully connected CircleCI with your repository and ran your first successful pipeline.
 
-Your first pipeline succeeded by processing the '.circleci/config.yml' file in your repository.  After you clicked Start Building, CircleCI spun up a clean container, installed the environment using the Docker executor and a custom 'welcome-config-image'. Then, CircleCI executed the steps specified by the 'run' job to print this text to the console.
+Your first pipeline succeeded by processing the '.circleci/config.yml' file in your repository.
+After you clicked Start Building, CircleCI spun up a clean container, installed the environment using the Docker executor and a custom 'welcome-config-image'.
+Then, CircleCI executed the steps specified by the 'run' job to print this text to the console.
 
-This happened because your project automatically registered webhooks with CircleCI. From now on, CircleCI will trigger a run when any member of your project pushes code.  When a run is triggered, CircleCI processes the '.circleci/config.yml' file in your repo, and runs a Pipeline of your configuration.
+This happened because your project automatically registered webhooks with CircleCI.
+From now on, CircleCI will trigger a run when any member of your project pushes code.
+When a run is triggered, CircleCI processes the '.circleci/config.yml' file in your repo, and runs a Pipeline of your configuration.
 
 Open the following console for ${UNDERLINED_TEXT}Next Steps${NORMAL_TEXT} to find information and links that will help to configure your builds, tests, deployments, and more."


### PR DESCRIPTION
### Checklist

- [x] All new jobs, commands, executors, parameters have descriptions
- [x] Examples have been added for any significant new features
- [x] README has been updated, if necessary

### Motivation, issues

This is a cosmetic change. The idea is to make the output nicer so users don't have to scroll horizontally (or not too much, depending on screen size).

### Description

- Put each sentence on a different line

### Note

- The changes got approved by the Activation team already. For the internal ticket number or links to the approval, feel free to ping me on our internal Slack `@melvin`.